### PR TITLE
fix for HA 0.74.0

### DIFF
--- a/service/emulated_hue_charley/__init__.py
+++ b/service/emulated_hue_charley/__init__.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/emulated_hue/
 """
 import logging
 
+from aiohttp import web
 import voluptuous as vol
 
 from homeassistant import util
@@ -13,13 +14,12 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.components.http import REQUIREMENTS  # NOQA
-from homeassistant.components.http import HomeAssistantHTTP
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.deprecation import get_deprecated
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.json import load_json, save_json
 from .hue_api import (
-    HueDingDongConfigView,HueUsernameView, HueAllLightsStateView, HueOneLightStateView,
+    HueDingDongConfigView, HueUsernameView, HueAllLightsStateView, HueOneLightStateView,
     HueOneLightChangeView)
 from .upnp import DescriptionXmlView, UPNPResponderThread
 
@@ -92,27 +92,17 @@ def setup(hass, yaml_config):
     timezone = yaml_config.get("homeassistant").get("time_zone")
     config = Config(hass, yaml_config.get(DOMAIN, {}), timezone)
 
+    app = web.Application()
+    app['hass'] = hass
+    handler = None
+    server = None
 
-    server = HomeAssistantHTTP(
-        hass,
-        server_host=config.host_ip_addr,
-        server_port=config.listen_port,
-        api_password=None,
-        ssl_certificate=None,
-        ssl_key=None,
-        cors_origins=None,
-        use_x_forwarded_for=False,
-        trusted_networks=[],
-        login_threshold=0,
-        is_ban_enabled=False
-    )
-
-    server.register_view(DescriptionXmlView(config))
-    server.register_view(HueDingDongConfigView(config))
-    server.register_view(HueUsernameView(config))
-    server.register_view(HueAllLightsStateView(config))
-    server.register_view(HueOneLightStateView(config))
-    server.register_view(HueOneLightChangeView(config))
+    DescriptionXmlView(config).register(app, app.router)
+    HueDingDongConfigView(config).register(app, app.router)
+    HueUsernameView().register(app, app.router)
+    HueAllLightsStateView(config).register(app, app.router)
+    HueOneLightStateView(config).register(app, app.router)
+    HueOneLightChangeView(config).register(app, app.router)
 
     upnp_listener = UPNPResponderThread(
         config.host_ip_addr, config.listen_port,
@@ -122,14 +112,31 @@ def setup(hass, yaml_config):
     async def stop_emulated_hue_bridge(event):
         """Stop the emulated hue bridge."""
         upnp_listener.stop()
-        await server.stop()
+        if server:
+            server.close()
+            await server.wait_closed()
+        await app.shutdown()
+        if handler:
+            await handler.shutdown(10)
+        await app.cleanup()
 
     async def start_emulated_hue_bridge(event):
         """Start the emulated hue bridge."""
         upnp_listener.start()
-        await server.start()
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, stop_emulated_hue_bridge)
+        nonlocal handler
+        nonlocal server
+
+        handler = app.make_handler(loop=hass.loop)
+
+        try:
+            server = await hass.loop.create_server(
+                handler, config.host_ip_addr, config.listen_port)
+        except OSError as error:
+            _LOGGER.error("Failed to create HTTP server at port %d: %s",
+                          config.listen_port, error)
+        else:
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STOP, stop_emulated_hue_bridge)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_emulated_hue_bridge)
 

--- a/service/emulated_hue_charley/hue_api.py
+++ b/service/emulated_hue_charley/hue_api.py
@@ -121,9 +121,6 @@ class HueUsernameView(HomeAssistantView):
     extra_urls = ['/api/']
     requires_auth = False
 
-    def __init__(self,config):
-        self.config = config
-
     @asyncio.coroutine
     def post(self, request):
         """Handle a POST request."""
@@ -135,13 +132,7 @@ class HueUsernameView(HomeAssistantView):
         if 'devicetype' not in data:
             return self.json_message('devicetype not specified',
                                      HTTP_BAD_REQUEST)
-        if self.config.type == "dingdong":
-            if self.config.auto_link:
-                return self.json([{'success': {'username': '12345678901234567890'}}])
-            else:
-                return self.json([{"error":{"type":"101","address":"/api/","description":"link button not pressed"}}])
-        else:
-            return self.json([{'success': {'username': '12345678901234567890'}}])
+        return self.json([{'success': {'username': '12345678901234567890'}}])
 
 class HueAllLightsStateView(HomeAssistantView):
     """Handle requests for getting and setting info about entities."""
@@ -306,11 +297,11 @@ class HueOneLightChangeView(HomeAssistantView):
                     # Convert 0-100 to a fan speed
                     if brightness == 0:
                         data[ATTR_SPEED] = SPEED_OFF
-                    elif brightness <= 33.3 and brightness > 0:
+                    elif 0 < brightness <= 33.3:
                         data[ATTR_SPEED] = SPEED_LOW
-                    elif brightness <= 66.6 and brightness > 33.3:
+                    elif 33.3 < brightness <= 66.6:
                         data[ATTR_SPEED] = SPEED_MEDIUM
-                    elif brightness <= 100 and brightness > 66.6:
+                    elif 66.6 < brightness <= 100:
                         data[ATTR_SPEED] = SPEED_HIGH
 
         if entity.domain in config.off_maps_to_on_domains:


### PR DESCRIPTION
[Decouple emulated hue from http server (#15530) ](https://github.com/home-assistant/home-assistant/commit/ca0d4226aa6a382662996a41a4004434350e76f5)
改完后hue_api.py报错，因为不熟悉python，把那一部分改成了和官方一样的处理方式，默认自动按下link按钮。
